### PR TITLE
Fix URL for dragonfly configuration reference

### DIFF
--- a/lib/generators/alchemy/install/templates/dragonfly.rb.tt
+++ b/lib/generators/alchemy/install/templates/dragonfly.rb.tt
@@ -7,7 +7,7 @@
 # http://markevans.github.io/dragonfly/cache/
 #
 # A complete reference can be found at
-# http://markevans.github.io/dragonfly/configuration/
+# http://markevans.github.io/dragonfly/configuration
 #
 # Pictures
 #


### PR DESCRIPTION
## What is this pull request for?

Remove trailing  `/` from URL in the comment

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
